### PR TITLE
AWS SDK and STS integration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+keys.js
 .idea
 .DS_Store
 *.DS_Store

--- a/app.js
+++ b/app.js
@@ -6,6 +6,9 @@ module.exports = function(){
 
 	var express = require('express');
 	var bodyParser = require('body-parser');
+	var aws = require('aws-sdk');
+	var sts = new aws.STS();
+	var keys = require('./keys'); 
 
 
 	var app = express();
@@ -15,6 +18,35 @@ module.exports = function(){
 
 	app.use(express.static(__dirname + '/public'));
 
+  /*
+  ** This is a sample endpoint to demonstrate the code
+  ** that is necessary to get an AWS STS token.
+  ** A keys.js file is needed in the root directory
+  ** to make this work.
+  ** The contents of the keys file should be...
+  ** var keys = {
+  **  accessKeyId: 'enter a real access key iD here',
+  **  secretAccessKey: 'enter a secret access key here'
+  ** };
+  */
+  // These are the credentials for the macmillan-front-end user.
+  aws.config.update({
+    accessKeyId: keys.accessKeyId,
+    secretAccessKey: keys.secretAccessKey
+  });
+
+  app.get('/token', function(req, res) {
+    var params = {
+      DurationSeconds: 3600
+    };
+    sts.getSessionToken(params, function(err, data) {
+      if (err) console.log(err, err.stack); // an error occurred
+      else {
+        res.setHeader('Content-Type', 'application/json');
+        res.send(JSON.stringify({ token: data }));
+      }
+    });
+  });
 
 	// alter response header so it doesn't say powered by expressJS
 	app.use(function(req, res, next){
@@ -25,4 +57,3 @@ module.exports = function(){
 	return app;
 
 }
-	

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "server.js",
   "dependencies": {
+    "aws-sdk": "^2.2.47",
     "body-parser": "^1.4.3",
     "express": "^4.5.1"
   },


### PR DESCRIPTION
The AWS keys required belong to the macmillan-front-end user in AWS.
