### PR TITLE
Updated gulpconfig to not include views-ignored when it compiles the …

### DIFF
--- a/gulpconfig/gulpconfig.js
+++ b/gulpconfig/gulpconfig.js
@@ -16,7 +16,8 @@ var paths = {
         './src/jsx-pages/**/*.css'
     ],
     partials: [
-        './src/views-*/**/*.html'
+        './src/views-*/**/*.html',
+        '!./src/views-ignored/**/*.html',
     ],
     thirdParty: [
         './src/js/lib/react-min.js',   // React MUST be first or it empties <body>                

--- a/src/views-ignored/ignoretest.html
+++ b/src/views-ignored/ignoretest.html
@@ -1,0 +1,3 @@
+<div class="ignored">
+	<h2>ignore</h2>
+</div>

--- a/src/views-ignored/ignoretest.spec.js
+++ b/src/views-ignored/ignoretest.spec.js
@@ -1,0 +1,6 @@
+describe('suite of tests to make sure ignored files are not included', function() {
+  it('should not have ignoretest partial in htmlpartials', function() {
+    console.log('Unit Test: The htmlpartials should not have ignoretest');
+      expect(typeof htmlpartials.ignoretest).toBe("undefined");
+  });
+});


### PR DESCRIPTION
…html partials, added example ignored file and test to make sure it is not included.

Currently, you cannot specify multiple entries in the array to include as per this 3rd party issue:
https://github.com/briangonzalez/gulp-file-contents-to-json/issues/5

However the not (!) syntax produces expected results, but can be replaced with explicit multiple paths once resolved.
